### PR TITLE
compress: don't try to copy NULL string

### DIFF
--- a/src/compress.c
+++ b/src/compress.c
@@ -517,7 +517,10 @@ uncompresszlib(const unsigned char *old, unsigned char **newch,
 
 	return OKDATA;
 err:
-	strlcpy((char *)*newch, z.msg, bytes_max);
+	if (z.msg != NULL)
+		strlcpy((char *)*newch, z.msg, bytes_max);
+	else
+		strlcpy((char *)*newch, zError(rc), bytes_max);
 	*n = strlen((char *)*newch);
 	return ERRDATA;
 }


### PR DESCRIPTION
In zlib there are few functions which can fail and set msg
to NULL instead of some message.

if we pass NULL as source then strlcpy just crashes because it
tries to dereference NULL-pointer so for error reporting when
msg is NULL we will just convert rc to message via zError().

In case of RPM's usage inflate() was returning Z_NEED_DICT.

References: https://bugzilla.redhat.com/show_bug.cgi?id=1350252
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>