### PR TITLE
completed common sample frequencies for pcm encoded audio in flac containers using bash script 

### DIFF
--- a/magic/Magdir/audio
+++ b/magic/Magdir/audio
@@ -468,20 +468,26 @@
 >>20	byte&0xe		0xa		\b, 6 channels
 >>20	byte&0xe		0xc		\b, 7 channels
 >>20	byte&0xe		0xe		\b, 8 channels
+# sample rates derived from known oscillator frequencies;
+# 24.576 MHz (video/fs=48kHz), 22.5792 (audio/fs=44.1kHz) and
+# 16.384 (other/fs=32kHz).
+>>17	belong&0xfffff0       	0x02b110	\b, 11.025 kHz
+>>17	belong&0xfffff0       	0x03e800	\b, 16 kHz
+>>17	belong&0xfffff0       	0x056220	\b, 22.05 kHz
+>>17	belong&0xfffff0       	0x05dc00	\b, 24 kHz
+>>17	belong&0xfffff0       	0x07d000	\b, 32 kHz
+>>17	belong&0xfffff0       	0x0ac440	\b, 44.1 kHz
+>>17	belong&0xfffff0       	0x0bb800	\b, 48 kHz
+>>17	belong&0xfffff0       	0x0fa000	\b, 64 kHz
+>>17	belong&0xfffff0       	0x158880	\b, 88.2 kHz
+>>17	belong&0xfffff0       	0x177000	\b, 96 kHz
+>>17	belong&0xfffff0       	0x1f4000	\b, 128 kHz
+>>17	belong&0xfffff0       	0x2b1100	\b, 176.4 kHz
+>>17	belong&0xfffff0       	0x2ee000	\b, 192 kHz
+>>17	belong&0xfffff0       	0x3e8000	\b, 256 kHz
+>>17	belong&0xfffff0       	0x562200	\b, 352.8 kHz
+>>17	belong&0xfffff0       	0x5dc000	\b, 384 kHz
 # some common sample rates
->>17	belong&0xfffff0		0x2ee000	\b, 192 kHz
->>17	belong&0xfffff0		0x158880	\b, 88.2 kHz
->>17	belong&0xfffff0		0x0ac440	\b, 44.1 kHz
->>17	belong&0xfffff0		0x0bb800	\b, 48 kHz
->>17	belong&0xfffff0		0x07d000	\b, 32 kHz
->>17	belong&0xfffff0		0x056220	\b, 22.05 kHz
->>17	belong&0xfffff0		0x05dc00	\b, 24 kHz
->>17	belong&0xfffff0		0x03e800	\b, 16 kHz
->>17	belong&0xfffff0		0x02b110	\b, 11.025 kHz
->>17	belong&0xfffff0		0x02ee00	\b, 12 kHz
->>17	belong&0xfffff0		0x01f400	\b, 8 kHz
->>17	belong&0xfffff0		0x177000	\b, 96 kHz
->>17	belong&0xfffff0		0x0fa000	\b, 64 kHz
 >>21	byte&0xf		>0		\b, >4G samples
 >>21	byte&0xf		0		\b
 >>>22	belong			>0		\b, %u samples

--- a/magic/create_filemagic_flac
+++ b/magic/create_filemagic_flac
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+## bash script to generate file magic support for flac.
+## https://github.com/file/file/blob/master/magic/Magdir/audio
+## below "#some common sample rates" (line 471), ie:
+## >>17	belong&0xfffff0		0x2ee000	\b, 192 kHz
+
+LANG=C
+
+target=magic/Magdir/audio
+
+## construct static list of sample rates based on standard crystal
+## oscillator frequencies.
+## 16.384  MHz Unknown audio application
+##             (16384 kHz  = 32 kHz * 512 = 32 * 2^9)
+## 22.5792 MHz Redbook/CD
+##             (22579.2 kHz = 44.1kHz * 512 = 44.1 * 2^9)
+##             also used: 11.2896, 16.9344, 33.8688 and 45.1584
+## 24.576  MHz DAT/Video
+##             (24576 kHz = 48 kHz * 512 = 48 * 2^9)
+##             also used: 49.1520
+
+## 33.8688 > 16.9344
+## 36.864  > 18.432000
+declare -a a_ground_fs=(16384000 22579200 24576000)
+
+## multiply ground clock frequencies by 1953 to get usable base
+## frequencies, for instance:
+##  DAT/video:  24.576  MHz * 1000000 / 512 = 48000Hz
+##  Redbook/CD: 22.5792 MHz * 1000000 / 512 = 44100Hz
+## use base rates for calculating derived rates
+declare -a samplerates
+## min divider: fs/n
+def_fs_n=512
+min_fs_n=4
+## start at base_fs/(def_fs*min_fs)
+## add each derived sample rate to the array
+for base_fs in "${a_ground_fs[@]}"; do 
+    min_fs=$( echo "${base_fs} / ( ${def_fs_n} * ${min_fs_n} )" | bc)
+    ## max multiplier: fs*n*min_fs
+    max_fs_n=$(( 8 * min_fs_n ))
+    n=${max_fs_n}
+    while [[ ${n} -ge 1 ]]; do
+	sample_rate=$(( min_fs * n ))
+	samplerates+=(${sample_rate})
+	n=$(( n / 2 ))
+    done
+done
+
+declare -a stripped_rates
+declare -a lines
+for samplerate in "${samplerates[@]}"; do
+    ## use bc with sed to convert and format Hz to kHz
+    stripped_rate="$(LANG=C bc <<< "scale=5; ${samplerate} / 1000" | \
+			      sed 's#[0\.]*$##g')"
+    ## only add uniq sample rates (should be neccessary
+    if [[ ! "${stripped_rates[@]}" =~ ${stripped_rate} ]]; then
+	printf -v line ">>17\tbelong&%#-15x\t%#08x\t%s, %s kHz\n" \
+	       "16777200" \
+	       "$(( samplerate * 16 ))" \
+	       "\b" \
+	       "${stripped_rate}"
+	stripped_rates+=("${stripped_rate}")
+	lines+=("${line}")
+    fi
+
+done
+printf "## start cutting >>> \n"
+## print out the formatted lines
+printf "%s" "${lines[@]}" | sort -k5 -n
+printf "## <<< stop cutting\n"
+
+


### PR DESCRIPTION
- using script `magic/create_filemagic_flac`:
- added missing frequencies based on fs=44.1kHz (176.4, 352.8) 
- added missing frequencies based on fs=48kHz (384) 
- sorted the output
