### PR TITLE
Flac magic

### DIFF
--- a/magic/Magdir/audio
+++ b/magic/Magdir/audio
@@ -6,6 +6,7 @@
 # Jan Nicolai Langfeldt (janl@ifi.uio.no), Dan Quinlan (quinlan@yggdrasil.com),
 # and others
 #
+# Also see iff for AIFF and such.
 
 # Sun/NeXT audio data
 0	string		.snd		Sun/NeXT audio data:
@@ -471,22 +472,22 @@
 # sample rates derived from known oscillator frequencies;
 # 24.576 MHz (video/fs=48kHz), 22.5792 (audio/fs=44.1kHz) and
 # 16.384 (other/fs=32kHz).
->>17	belong&0xfffff0       	0x02b110	\b, 11.025 kHz
->>17	belong&0xfffff0       	0x03e800	\b, 16 kHz
->>17	belong&0xfffff0       	0x056220	\b, 22.05 kHz
->>17	belong&0xfffff0       	0x05dc00	\b, 24 kHz
->>17	belong&0xfffff0       	0x07d000	\b, 32 kHz
->>17	belong&0xfffff0       	0x0ac440	\b, 44.1 kHz
->>17	belong&0xfffff0       	0x0bb800	\b, 48 kHz
->>17	belong&0xfffff0       	0x0fa000	\b, 64 kHz
->>17	belong&0xfffff0       	0x158880	\b, 88.2 kHz
->>17	belong&0xfffff0       	0x177000	\b, 96 kHz
->>17	belong&0xfffff0       	0x1f4000	\b, 128 kHz
->>17	belong&0xfffff0       	0x2b1100	\b, 176.4 kHz
->>17	belong&0xfffff0       	0x2ee000	\b, 192 kHz
->>17	belong&0xfffff0       	0x3e8000	\b, 256 kHz
->>17	belong&0xfffff0       	0x562200	\b, 352.8 kHz
->>17	belong&0xfffff0       	0x5dc000	\b, 384 kHz
+>>17	belong&0xfffff0       	0x02b110	\b, 11025 Hz
+>>17	belong&0xfffff0       	0x03e800	\b, 16000 Hz
+>>17	belong&0xfffff0       	0x056220	\b, 22050 Hz
+>>17	belong&0xfffff0       	0x05dc00	\b, 24000 Hz
+>>17	belong&0xfffff0       	0x07d000	\b, 32000 Hz
+>>17	belong&0xfffff0       	0x0ac440	\b, 44100 Hz
+>>17	belong&0xfffff0       	0x0bb800	\b, 48000 Hz
+>>17	belong&0xfffff0       	0x0fa000	\b, 64000 Hz
+>>17	belong&0xfffff0       	0x158880	\b, 88200 Hz
+>>17	belong&0xfffff0       	0x177000	\b, 96000 Hz
+>>17	belong&0xfffff0       	0x1f4000	\b, 128000 Hz
+>>17	belong&0xfffff0       	0x2b1100	\b, 176400 Hz
+>>17	belong&0xfffff0       	0x2ee000	\b, 192000 Hz
+>>17	belong&0xfffff0       	0x3e8000	\b, 256000 Hz
+>>17	belong&0xfffff0       	0x562200	\b, 352800 Hz
+>>17	belong&0xfffff0       	0x5dc000	\b, 384000 Hz
 # some common sample rates
 >>21	byte&0xf		>0		\b, >4G samples
 >>21	byte&0xf		0		\b

--- a/magic/Magdir/audio
+++ b/magic/Magdir/audio
@@ -468,20 +468,26 @@
 >>20	byte&0xe		0xa		\b, 6 channels
 >>20	byte&0xe		0xc		\b, 7 channels
 >>20	byte&0xe		0xe		\b, 8 channels
+# sample rates derived from known oscillator frequencies;
+# 24.576 MHz (video/fs=48kHz), 22.5792 (audio/fs=44.1kHz) and
+# 16.384 (other/fs=32kHz).
+>>17	belong&0xfffff0       	0x02b110	\b, 11.025 kHz
+>>17	belong&0xfffff0       	0x03e800	\b, 16 kHz
+>>17	belong&0xfffff0       	0x056220	\b, 22.05 kHz
+>>17	belong&0xfffff0       	0x05dc00	\b, 24 kHz
+>>17	belong&0xfffff0       	0x07d000	\b, 32 kHz
+>>17	belong&0xfffff0       	0x0ac440	\b, 44.1 kHz
+>>17	belong&0xfffff0       	0x0bb800	\b, 48 kHz
+>>17	belong&0xfffff0       	0x0fa000	\b, 64 kHz
+>>17	belong&0xfffff0       	0x158880	\b, 88.2 kHz
+>>17	belong&0xfffff0       	0x177000	\b, 96 kHz
+>>17	belong&0xfffff0       	0x1f4000	\b, 128 kHz
+>>17	belong&0xfffff0       	0x2b1100	\b, 176.4 kHz
+>>17	belong&0xfffff0       	0x2ee000	\b, 192 kHz
+>>17	belong&0xfffff0       	0x3e8000	\b, 256 kHz
+>>17	belong&0xfffff0       	0x562200	\b, 352.8 kHz
+>>17	belong&0xfffff0       	0x5dc000	\b, 384 kHz
 # some common sample rates
->>17	belong&0xfffff0		0x2ee000	\b, 192 kHz
->>17	belong&0xfffff0		0x158880	\b, 88.2 kHz
->>17	belong&0xfffff0		0x0ac440	\b, 44.1 kHz
->>17	belong&0xfffff0		0x0bb800	\b, 48 kHz
->>17	belong&0xfffff0		0x07d000	\b, 32 kHz
->>17	belong&0xfffff0		0x056220	\b, 22.05 kHz
->>17	belong&0xfffff0		0x05dc00	\b, 24 kHz
->>17	belong&0xfffff0		0x03e800	\b, 16 kHz
->>17	belong&0xfffff0		0x02b110	\b, 11.025 kHz
->>17	belong&0xfffff0		0x02ee00	\b, 12 kHz
->>17	belong&0xfffff0		0x01f400	\b, 8 kHz
->>17	belong&0xfffff0		0x177000	\b, 96 kHz
->>17	belong&0xfffff0		0x0fa000	\b, 64 kHz
 >>21	byte&0xf		>0		\b, >4G samples
 >>21	byte&0xf		0		\b
 >>>22	belong			>0		\b, %u samples

--- a/magic/Magdir/iff
+++ b/magic/Magdir/iff
@@ -1,4 +1,3 @@
-
 #------------------------------------------------------------------------------
 # $File: iff,v 1.13 2011/09/06 11:00:06 christos Exp $
 # iff:	file(1) magic for Interchange File Format (see also "audio" & "images")
@@ -7,16 +6,101 @@
 # Arts for file interchange.  It has also been used by Apple, SGI, and
 # especially Commodore-Amiga.
 #
+# Ronald van Engelen (ronalde@lacocina.nl) -- Output formatted like WAV(E) RIFF
+# files, except for sample rate(1):
+#   RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, stereo 44100 Hz
+#   IFF (big-endian) data, AIFF audio, Linear PCM, 16 bit, stereo, (1 * 44100) Hz.
+#
 # IFF files begin with an 8 byte FORM header, followed by a 4 character
 # FORM type, which is followed by the first chunk in the FORM.
-
-0	string		FORM		IFF data
-#>4	belong		x		\b, FORM is %d bytes long
-# audio formats
->8	string		AIFF		\b, AIFF audio
+#
+# AIFF
+#  a. >> 0 FORM AIFF Chunk
+#  b. >> 4 ID             chunkID;           4 bytes: FORM
+#  c. >> 8                formType;          4 bytes: AIFF or AIFC
+#     >>12
+#
+# for audio the chunk with chunkID 'COMM' contains STREAMINFO with
+# the following layout:
+#  d. >>+ 0  ++ 0 (12) ID             chunkID;           4 bytes=COMM
+#  e. >>+ 4  ++ 4 (16) long           chunkSize;         4 bytes=18 or 23
+#  f. >>+ 4  ++ 8 (20) short          numChannels;       2 bytes=0x1, 0x2, ..., 0x6
+#  g. >>+ 2  ++10 (22) unsigned long  numSampleFrames;   4 bytes
+#  h. >>+ 4  ++14 (26) short          sampleSize;        2 bytes=4, 8, 16 or 24
+#  i. >>+ 2  ++16 (28) extended       sampleRate;       10 bytes
+#     >>+10  ++26 (38)
+#  Ad (1): sampleRate is an extended 80bit float; to reconstruct the sample
+#  rate in Hz one has to perform the following calculations, which seem
+#  impossible in current file magic implementation:
+#  (courtesy https://cycling74.com/forums/aiffs-80-bit-sample-rate-value/)
+#     lsb_pad=value of 2 bytes at >>&12 minus 16398 (either 0, 1, 2 or 3)
+#     base1=value of byte at >>&14 (either 172 for base freq 44100 or 187 for 48000)
+#     base2=value of byte at >>&14 (either 68  for base freq 44100 or 128 for 48000)
+#  first bit shift ${base1} 8 bits left,
+#  then add ${base2} and bit shift the sum with ${lsb_pas} bits left.
+#  in bash syntax:
+#     samplerate=$(( ( (${base1} << 8 ) + ${base2}) << ${lsb_pad} ))
+#  or:
+#     samplerate=$(echo "((${base1}*2^8)+${base2})*(2^${lsb_pad}) | bc)
+#  or, to simplify:
+#     base_freq=value of unsigned 2 bytes at >>&14
+#               (either 44100 (0xac44) or 48000 (0xbb80))
+#     samplerate=$(( (${lsb_pad}+1)*${base_freq} ))
+#
+#  a. >> 0 FORM AIFF Chunk
+#  b. >> 4 ID            chunkID;           4 bytes: FORM
+0	string		FORM		IFF (big-endian) data
+#  c. >> 8                formType;          4 bytes: AIFF or AIFC
+>8	string		AIFF		\b, AIFF audio, Linear PCM
 !:mime	audio/x-aiff
+# COMM chunk
+#  d. >>+ 0  ++ 0 (12) ID             chunkID;           4 bytes=COMM
+>>&0 	search 	        COMM
+#  e. >>+ 4  ++ 4 (16) long           chunkSize;         4 bytes=18 (or non standard 23)
+#>>>&0	belong	       x	     	\b, chunkSize=%d
+>>>&0	belong	       0x12
+>>>&0	belong	       0x17
+#  h. >>+ 4  ++14 (26) short          sampleSize;        2 bytes
+>>>&10	beshort	       x		\b, %d bit
+#  f. >>+ 4  ++ 8 (20) short          numChannels;       2 bytes: 0x0, 0x1, 0x2 ...
+#>>>&4	beshort	       x		\b, numChannels=%d
+>>>&4	beshort	       0x1		\b, mono
+>>>&4	beshort	       0x2		\b, stereo
+>>>&4	beshort	       0x3		\b, 3 channels
+>>>&4	beshort	       0x4		\b, 4 channels
+>>>&4	beshort	       0x5		\b, 5 channels
+>>>&4	beshort	       0x6		\b, 6 channels
+#  i. >>+ 2  ++16 (28) extended       sampleRate;       10 bytes
+# lsb-pad
+#>>>&12 beshort-16398  x		\b, lsbPad-16398*=%d
+>>>&12 	beshort-16398  0		\b, (1 *
+>>>&12 	beshort-16398  1		\b, (2 *
+>>>&12 	beshort-16398  2		\b, (3 *
+>>>&12 	beshort-16398  3		\b, (4 *
+>>>&14 ubeshort        0xac44		\b 44100) Hz
+>>>&14 ubeshort        0xbb80		\b 48000) Hz
+# to clairfy, what would be needed is something like this (bash syntax):
+# case ">>&14 ubeshort" in
+#  0xac44)
+#   case pad_size in
+#   	 0) samplerate=44100 ;;
+#  	 1) samplerate=88200 ;;
+#  	 2) samplerate=176400 ;;
+#  	 3) samplerate=352800 ;;
+#   esac
+#  0xbb80)
+#   	 0) samplerate=48000 ;;
+#  	 1) samplerate=96000 ;;
+#  	 2) samplerate=192000 ;;
+#  	 3) samplerate=384800 ;;
+#   esac
+#  esac
+#  g. >>+ 2  ++10 (22) unsigned long  numSampleFrames;   4 bytes
+>>>&6	ubelong	       x		\b, %d samples
 >8	string		AIFC		\b, AIFF-C compressed audio
 !:mime	audio/x-aiff
+#
+# non AIFF audio IFF formats
 >8	string		8SVX		\b, 8SVX 8-bit sampled sound voice
 !:mime	audio/x-aiff
 >8	string		16SV		\b, 16SV 16-bit sampled sound voice

--- a/magic/create_filemagic_flac
+++ b/magic/create_filemagic_flac
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+## bash script to generate file magic support for flac.
+## https://github.com/file/file/blob/master/magic/Magdir/audio
+## below "#some common sample rates" (line 471), ie:
+## >>17	belong&0xfffff0		0x2ee000	\b, 192 kHz
+
+LANG=C
+
+target=magic/Magdir/audio
+
+## construct static list of sample rates based on standard crystal
+## oscillator frequencies.
+## 16.384  MHz Unknown audio application
+##             (16384 kHz  = 32 kHz * 512 = 32 * 2^9)
+## 22.5792 MHz Redbook/CD
+##             (22579.2 kHz = 44.1kHz * 512 = 44.1 * 2^9)
+##             also used: 11.2896, 16.9344, 33.8688 and 45.1584
+## 24.576  MHz DAT/Video
+##             (24576 kHz = 48 kHz * 512 = 48 * 2^9)
+##             also used: 49.1520
+
+## 33.8688 > 16.9344
+## 36.864  > 18.432000
+declare -a a_ground_fs=(16384000 22579200 24576000)
+
+## multiply ground clock frequencies by 1953 to get usable base
+## frequencies, for instance:
+##  DAT/video:  24.576  MHz * 1000000 / 512 = 48000Hz
+##  Redbook/CD: 22.5792 MHz * 1000000 / 512 = 44100Hz
+## use base rates for calculating derived rates
+declare -a samplerates
+## min divider: fs/n
+def_fs_n=512
+min_fs_n=4
+## start at base_fs/(def_fs*min_fs)
+## add each derived sample rate to the array
+for base_fs in "${a_ground_fs[@]}"; do 
+    min_fs=$( echo "${base_fs} / ( ${def_fs_n} * ${min_fs_n} )" | bc)
+    ## max multiplier: fs*n*min_fs
+    max_fs_n=$(( 8 * min_fs_n ))
+    n=${max_fs_n}
+    while [[ ${n} -ge 1 ]]; do
+	sample_rate=$(( min_fs * n ))
+	samplerates+=(${sample_rate})
+	n=$(( n / 2 ))
+    done
+done
+
+declare -a stripped_rates
+declare -a lines
+for samplerate in "${samplerates[@]}"; do
+    ## use bc with sed to convert and format Hz to kHz
+    stripped_rate="$(LANG=C bc <<< "scale=5; ${samplerate} / 1000" | \
+			      sed 's#[0\.]*$##g')"
+    ## only add uniq sample rates (should be neccessary
+    if [[ ! "${stripped_rates[@]}" =~ ${stripped_rate} ]]; then
+	printf -v line ">>17\tbelong&%#-15x\t%#08x\t%s, %s kHz\n" \
+	       "16777200" \
+	       "$(( samplerate * 16 ))" \
+	       "\b" \
+	       "${stripped_rate}"
+	stripped_rates+=("${stripped_rate}")
+	lines+=("${line}")
+    fi
+
+done
+printf "## start cutting >>> \n"
+## print out the formatted lines
+printf "%s" "${lines[@]}" | sort -k5 -n
+printf "## <<< stop cutting\n"
+
+

--- a/magic/create_filemagic_flac
+++ b/magic/create_filemagic_flac
@@ -47,23 +47,14 @@ for base_fs in "${a_ground_fs[@]}"; do
     done
 done
 
-declare -a stripped_rates
 declare -a lines
 for samplerate in "${samplerates[@]}"; do
-    ## use bc with sed to convert and format Hz to kHz
-    stripped_rate="$(LANG=C bc <<< "scale=5; ${samplerate} / 1000" | \
-			      sed 's#[0\.]*$##g')"
-    ## only add uniq sample rates (should be neccessary
-    if [[ ! "${stripped_rates[@]}" =~ ${stripped_rate} ]]; then
-	printf -v line ">>17\tbelong&%#-15x\t%#08x\t%s, %s kHz\n" \
-	       "16777200" \
-	       "$(( samplerate * 16 ))" \
-	       "\b" \
-	       "${stripped_rate}"
-	stripped_rates+=("${stripped_rate}")
-	lines+=("${line}")
-    fi
-
+    printf -v line ">>17\tbelong&%#-15x\t%#08x\t%s, %s Hz\n" \
+	   "16777200" \
+	   "$(( samplerate * 16 ))" \
+	   "\b" \
+	   "${samplerate}"
+    lines+=("${line}")
 done
 printf "## start cutting >>> \n"
 ## print out the formatted lines


### PR DESCRIPTION
- Addition to previous pull request for flac: changed sample rate units from kHz to Hz, to look more like RIFF/WAVE files
- Added details about AIFF audio files so that the output is much more informative

NOTE: the sample rate of AIFF files can't be printed in the output message. Instead I choose to use a clumsy yet informative `n*${samplerate}) Hz` notation. This is due to known limitations of file magic (no possibility for multiple conditions and/or calculations in the output message) in combination with the complexity of the 80bit extended floating point sample rate in the AIFF format.
