### PR TITLE
fix video/3gpp mime types

### DIFF
--- a/magic/Magdir/animation
+++ b/magic/Magdir/animation
@@ -56,20 +56,20 @@
 >>11	byte		6		\b, Release 6 MBMS Extended Presentations
 >>11	byte		7		\b, Release 7 MBMS Extended Presentations
 >8	string		3gg		\b, MPEG v4 system, 3GPP
->11	byte		6		\b, Release 6 General Profile
 !:mime	video/3gpp
+>>11	byte		6		\b, Release 6 General Profile
 >8	string		3gp		\b, MPEG v4 system, 3GPP
->11	byte		1		\b, Release %d (non existent)
->11	byte		2		\b, Release %d (non existent)
->11	byte		3		\b, Release %d (non existent)
->11	byte		4		\b, Release %d
->11	byte		5		\b, Release %d
->11	byte		6		\b, Release %d
->11	byte		7		\b, Release %d Streaming Servers
 !:mime	video/3gpp
+>>11	byte		1		\b, Release %d (non existent)
+>>11	byte		2		\b, Release %d (non existent)
+>>11	byte		3		\b, Release %d (non existent)
+>>11	byte		4		\b, Release %d
+>>11	byte		5		\b, Release %d
+>>11	byte		6		\b, Release %d
+>>11	byte		7		\b, Release %d Streaming Servers
 >8	string		3gs		\b, MPEG v4 system, 3GPP
->11	byte		7		\b, Release %d Streaming Servers
 !:mime	video/3gpp
+>>11	byte		7		\b, Release %d Streaming Servers
 >8	string		avc1		\b, MPEG v4 system, 3GPP JVT AVC [ISO 14496-12:2005]
 !:mime	video/mp4
 >8	string/W	qt		\b, Apple QuickTime movie


### PR DESCRIPTION
It seems like the mime type definitions in Magdir/animations do not work as intended for video/3gpp files.
First, there are version checks at byte 11 that are not at a deeper level than the checks at byte 8, so they would match e.g. anything with byte 11 being 7 even if the string starting at byte 8 is not "3gp".
Second, the mime types only get returned for match at the last >11 check, e.g. for 3gp only Release 7 would return type video/3gpp.

Seems like this behaviour was broken in https://github.com/file/file/commit/4a5da2ceadd456abfceb95171176384aefe323c4 when introducing the Release checks. This was done correctly for 3g2 and 3ge, but wrong for 3gg, 3gp and 3gs.
