### PR TITLE
Fix OpenSSL enc base64 file magic

### DIFF
--- a/magic/Magdir/ssl
+++ b/magic/Magdir/ssl
@@ -17,4 +17,4 @@
 # OpenSSL enc file (recognized by a magic string preceding the password's salt)
 0	string	Salted__	openssl enc'd data with salted password
 # Using the -a or -base64 option, OpenSSL will base64-encode the data.
-0	string U2FsdGVkX19	openssl enc'd data with salted password, base64 encoded
+0	string U2FsdGVkX1	openssl enc'd data with salted password, base64 encoded


### PR DESCRIPTION
The `Salted__` string does not always end with `9`, the last character depends on the next byte, which is the salt for the key.  Obviously it can be any byte.