### PR TITLE
 added missing syscalls to seccomp whitelist 

### DIFF
--- a/src/seccomp.c
+++ b/src/seccomp.c
@@ -177,6 +177,7 @@ enable_sandbox_full(void)
 	ALLOW_RULE(mmap);
 	ALLOW_RULE(mprotect);
 	ALLOW_RULE(mremap);
+	ALLOW_RULE(msgget);
 	ALLOW_RULE(munmap);
 	ALLOW_RULE(open);
 	ALLOW_RULE(openat);

--- a/src/seccomp.c
+++ b/src/seccomp.c
@@ -182,6 +182,7 @@ enable_sandbox_full(void)
 	ALLOW_RULE(openat);
 	ALLOW_RULE(pread64);
 	ALLOW_RULE(read);
+	ALLOW_RULE(readlink);
 	ALLOW_RULE(rt_sigaction);
 	ALLOW_RULE(rt_sigprocmask);
 	ALLOW_RULE(rt_sigreturn);
@@ -196,7 +197,6 @@ enable_sandbox_full(void)
 	// needed by valgrind
 	ALLOW_RULE(gettid);
 	ALLOW_RULE(getpid);
-	ALLOW_RULE(readlink);
 	ALLOW_RULE(rt_sigtimedwait);
 #endif
 

--- a/src/seccomp.c
+++ b/src/seccomp.c
@@ -171,6 +171,7 @@ enable_sandbox_full(void)
 	ALLOW_RULE(fcntl);  
 	ALLOW_RULE(fstat);
 	ALLOW_RULE(getdents);
+	ALLOW_RULE(getpid);
 	ALLOW_RULE(ioctl);
 	ALLOW_RULE(lseek);
 	ALLOW_RULE(lstat);
@@ -178,6 +179,8 @@ enable_sandbox_full(void)
 	ALLOW_RULE(mprotect);
 	ALLOW_RULE(mremap);
 	ALLOW_RULE(msgget);
+	ALLOW_RULE(msgsnd);
+	ALLOW_RULE(msgrcv);
 	ALLOW_RULE(munmap);
 	ALLOW_RULE(open);
 	ALLOW_RULE(openat);
@@ -188,6 +191,8 @@ enable_sandbox_full(void)
 	ALLOW_RULE(rt_sigprocmask);
 	ALLOW_RULE(rt_sigreturn);
 	ALLOW_RULE(select);
+	ALLOW_RULE(semget);
+	ALLOW_RULE(semop);
 	ALLOW_RULE(stat);
 	ALLOW_RULE(sysinfo);
 	ALLOW_RULE(unlink);


### PR DESCRIPTION
File sometimes reports missing syscalls (when compiling other software)

New syscalls added to whitelist:

getpid
msgget
msgsnd
msgrcv
semget
semop