### PR TITLE
Properly report the mimetype for alternate-header zip files.

### DIFF
--- a/magic/Magdir/archive
+++ b/magic/Magdir/archive
@@ -1246,6 +1246,8 @@
 
 # Alternate ZIP string (amc@arwen.cs.berkeley.edu)
 0	string	PK00PK\003\004	Zip archive data
+!:mime	application/zip
+!:ext zip/cbz
 
 # ACE archive (from http://www.wotsit.org/download.asp?f=ace)
 # by Stefan `Sec` Zehl <sec@42.org>


### PR DESCRIPTION
Basically, I have a number of zip files for which the reported mime-type is not correct. 

```

durr@cr-build:/<snip>$ file ./stories/55A/55A1F13CEE852E739BEF3917AD8E31CD.zip
./stories/55A/55A1F13CEE852E739BEF3917AD8E31CD.zip: Zip archive data
durr@cr-build:/<snip>$ file ./stories/55A/55A1F13CEE852E739BEF3917AD8E31CD.zip --mime
./stories/55A/55A1F13CEE852E739BEF3917AD8E31CD.zip: application/octet-stream; charset=binary

```

This is really annoying, as I've been using the mimetype return (via libmagic) for file type autodetection, and it causes these particular files to be unopeneable.

Anyways, this is PR-ed here, because the "official" site seems to be completely dead. www.darwinsys.com and http://bugs.gw.com/ are both timing out.