### PR TITLE
Detect Microsoft Office XML files generated with different file order in ZIP

### DIFF
--- a/magic/Magdir/msooxml
+++ b/magic/Magdir/msooxml
@@ -33,4 +33,13 @@
 !:mime application/vnd.openxmlformats-officedocument.presentationml.presentation
 >>>>&26		string		xl/		Microsoft Excel 2007+
 !:mime application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
->>>>&26		default		x		Microsoft OOXML
+>>>>&26		default		x
+# OpenOffice/Libreoffice orders ZIP entry differently, so check the 4th file for them
+>>>>>&26	search/1000	PK\003\004
+>>>>>>&26	string		word/		Microsoft Word 2007+
+!:mime application/vnd.openxmlformats-officedocument.wordprocessingml.document
+>>>>>>&26	string		ppt/		Microsoft PowerPoint 2007+
+!:mime application/vnd.openxmlformats-officedocument.presentationml.presentation
+>>>>>>&26	string		xl/		Microsoft Excel 2007+
+!:mime application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+>>>>>>&26	default		x		Microsoft OOXML

--- a/tests/issue359xlsx.result
+++ b/tests/issue359xlsx.result
@@ -1,1 +1,1 @@
-Microsoft OOXML
+Microsoft Excel 2007+


### PR DESCRIPTION
Hello,

I found that OpenOffice/LibreOffice create Microsoft Office XML files with a different file order than Microsoft Office does. ECMA-376 Part 2 describes the ZIP file structure but does not mention any specific order the items should have so the files created by OpenOffice/LibreOffice are valid OOXML files.

OpenOffice/LibreOffice generated files contain the first file entry that can be used to determine the actual type from in the forth position, not the third. This seems to have been noted already, as the test "issue359xlsx" already checks for a file with other order, but the bugtracker and mailinglist are not accessible so I could not find out what discussion happened there.

Please consider to include this patch to improve OOXML detection as a lot of other projects rely on mime type detection by the file program and/or libmagic, e.g.:

https://github.com/LibraryOfCongress/viewshare/issues/144
https://github.com/thoughtbot/paperclip/issues/1530
https://github.com/symfony/symfony/issues/22702

Thanks for your work,
Dennis