### PR TITLE
Fix seccomp usability

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -337,15 +337,18 @@ main(int argc, char *argv[])
 	if (e)
 		return e;
 
+
+    if ((flags & MAGIC_COMPRESS) == 0 ){
 #ifdef HAVE_LIBSECCOMP
 #if 0
-	if (sandbox && enable_sandbox_basic() == -1)
+	    if (sandbox && enable_sandbox_basic() == -1)
 #else
-	if (sandbox && enable_sandbox_full() == -1)
+	    if (sandbox && enable_sandbox_full() == -1)
 #endif
-		file_err(EXIT_FAILURE, "SECCOMP initialisation failed");
+		    file_err(EXIT_FAILURE, "SECCOMP initialisation failed");
 #endif /* HAVE_LIBSECCOMP */
 
+    }
 	if (MAGIC_VERSION != magic_version())
 		file_warnx("Compiled magic version [%d] "
 		    "does not match with shared library magic version [%d]\n",


### PR DESCRIPTION
Currently the sandbox feature in file breaks other applications that use the decompression feature.
Distributions like Arch have disabled seccomp as a consequence https://git.archlinux.org/svntogit/packages.git/commit/trunk?h=packages/file&id=b4bd7d8a113562226d9736593acddcba68a141c3

(Also see thsi discussion https://github.com/file/file/pull/20)

To have a functional sandbox that can actually be used without making major changes in other applications that use file, the behavior needs to be adapted.

Having seccomp disabled when decompression is used will provide more security then having seccomp being disabled by distributions because it breaks things.
