### PR TITLE
Remove HAVE_LIMITS_H

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -91,7 +91,7 @@ AC_HEADER_STDC
 AC_HEADER_MAJOR
 AC_HEADER_SYS_WAIT
 AC_CHECK_HEADERS(stdint.h fcntl.h locale.h stdint.h inttypes.h unistd.h)
-AC_CHECK_HEADERS(stddef.h utime.h wchar.h wctype.h limits.h)
+AC_CHECK_HEADERS(stddef.h utime.h wchar.h wctype.h)
 AC_CHECK_HEADERS(getopt.h err.h xlocale.h signal.h)
 AC_CHECK_HEADERS(sys/mman.h sys/stat.h sys/types.h sys/utime.h sys/time.h)
 if test "$enable_zlib" != "no"; then

--- a/src/apprentice.c
+++ b/src/apprentice.c
@@ -51,9 +51,7 @@ FILE_RCSID("@(#)$File: apprentice.c,v 1.279 2018/09/09 20:33:28 christos Exp $")
 #include <sys/mman.h>
 #endif
 #include <dirent.h>
-#if defined(HAVE_LIMITS_H)
 #include <limits.h>
-#endif
 
 
 #define	EATAB {while (isascii((unsigned char) *l) && \

--- a/src/cdf.c
+++ b/src/cdf.c
@@ -47,9 +47,7 @@ FILE_RCSID("@(#)$File: cdf.c,v 1.111 2018/09/09 20:33:28 christos Exp $")
 #include <string.h>
 #include <time.h>
 #include <ctype.h>
-#ifdef HAVE_LIMITS_H
 #include <limits.h>
-#endif
 
 #ifndef EFTYPE
 #define EFTYPE EINVAL

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -42,9 +42,7 @@ FILE_RCSID("@(#)$File: funcs.c,v 1.99 2018/08/20 10:08:18 christos Exp $")
 #if defined(HAVE_WCTYPE_H)
 #include <wctype.h>
 #endif
-#if defined(HAVE_LIMITS_H)
 #include <limits.h>
-#endif
 
 #ifndef SIZE_MAX
 #define SIZE_MAX	((size_t)~0)

--- a/src/magic.c
+++ b/src/magic.c
@@ -44,9 +44,7 @@ FILE_RCSID("@(#)$File: magic.c,v 1.105 2018/08/02 12:53:51 christos Exp $")
 #ifdef QUICK
 #include <sys/mman.h>
 #endif
-#ifdef HAVE_LIMITS_H
 #include <limits.h>	/* for PIPE_BUF */
-#endif
 
 #if defined(HAVE_UTIMES)
 # include <sys/time.h>

--- a/src/vasprintf.c
+++ b/src/vasprintf.c
@@ -116,9 +116,7 @@ FILE_RCSID("@(#)$File: vasprintf.c,v 1.15 2018/09/09 20:33:28 christos Exp $")
 #include <stdlib.h>
 #include <stdarg.h>
 #include <ctype.h>
-#ifdef HAVE_LIMITS_H
 #include <limits.h>
-#endif
 #ifdef HAVE_STDDEF_H
 #include <stddef.h>
 #endif


### PR DESCRIPTION
The `<limits.h>` header file is part of the standard C89 headers [1] and
on current systems there is no need to manually check if header is
present anymore.

Since the code requires at least C89 or greater, the `HAVE_LIMITS_H`
symbol defined by Autoconf in configure.ac [2] can be removed and
simplifed.

Refs:
[1] https://port70.net/~nsz/c/c89/c89-draft.html#4.1.2
[2] https://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/headers.m4

Thank you.