### PR TITLE
Remove HAVE_LOCALE_H

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -90,7 +90,7 @@ dnl Checks for headers
 AC_HEADER_STDC
 AC_HEADER_MAJOR
 AC_HEADER_SYS_WAIT
-AC_CHECK_HEADERS(stdint.h fcntl.h locale.h stdint.h inttypes.h unistd.h)
+AC_CHECK_HEADERS(stdint.h fcntl.h stdint.h inttypes.h unistd.h)
 AC_CHECK_HEADERS(stddef.h utime.h wchar.h wctype.h limits.h)
 AC_CHECK_HEADERS(getopt.h err.h xlocale.h signal.h)
 AC_CHECK_HEADERS(sys/mman.h sys/stat.h sys/types.h sys/utime.h sys/time.h)

--- a/src/file.h
+++ b/src/file.h
@@ -513,9 +513,7 @@ protected void buffer_init(struct buffer *, int, const void *, size_t);
 protected void buffer_fini(struct buffer *);
 protected int buffer_fill(const struct buffer *);
 
-#if defined(HAVE_LOCALE_H)
 #include <locale.h>
-#endif
 #if defined(HAVE_XLOCALE_H)
 #include <xlocale.h>
 #endif


### PR DESCRIPTION
The `<locale.h>` header file is part of the standard C89 headers [1]
and on current systems can be included unconditionally.

Since file requires at least C89 or greater, the `HAVE_LOCALE_H` symbol
defined by Autoconf in configure.ac [2] can be ommitted and simplifed.

Refs:
[1] https://port70.net/~nsz/c/c89/c89-draft.html#4.1.2
[2] https://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/headers.m4

Thank you.