### PR TITLE
Remove HAVE_STDDEF_H

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -91,7 +91,7 @@ AC_HEADER_STDC
 AC_HEADER_MAJOR
 AC_HEADER_SYS_WAIT
 AC_CHECK_HEADERS(stdint.h fcntl.h locale.h stdint.h inttypes.h unistd.h)
-AC_CHECK_HEADERS(stddef.h utime.h wchar.h wctype.h limits.h)
+AC_CHECK_HEADERS(utime.h wchar.h wctype.h limits.h)
 AC_CHECK_HEADERS(getopt.h err.h xlocale.h signal.h)
 AC_CHECK_HEADERS(sys/mman.h sys/stat.h sys/types.h sys/utime.h sys/time.h)
 if test "$enable_zlib" != "no"; then

--- a/src/apprentice.c
+++ b/src/apprentice.c
@@ -40,9 +40,7 @@ FILE_RCSID("@(#)$File: apprentice.c,v 1.279 2018/09/09 20:33:28 christos Exp $")
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 #include <string.h>
 #include <assert.h>
 #include <ctype.h>

--- a/src/vasprintf.c
+++ b/src/vasprintf.c
@@ -119,9 +119,7 @@ FILE_RCSID("@(#)$File: vasprintf.c,v 1.15 2018/09/09 20:33:28 christos Exp $")
 #ifdef HAVE_LIMITS_H
 #include <limits.h>
 #endif
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
 
 #define ALLOC_CHUNK 2048
 #define ALLOC_SECURITY_MARGIN 1024   /* big value because some platforms have very big 'G' exponent */


### PR DESCRIPTION
The `<stddef.h>` header file is part of the standard C89 headers [1]
and on current systems can be included unconditionally.

Since file requires at least C89 or greater, the `HAVE_STDDEF_H` symbol
defined by Autoconf in `configure.ac` [2] can be ommitted and simplifed.

Refs:
[1] https://port70.net/~nsz/c/c89/c89-draft.html#4.1.2
[2] https://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/headers.m4

Thank you.