### PR TITLE
Remove HAVE_SIGNAL_H

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,15 +92,12 @@ AC_HEADER_MAJOR
 AC_HEADER_SYS_WAIT
 AC_CHECK_HEADERS(stdint.h fcntl.h locale.h stdint.h inttypes.h unistd.h)
 AC_CHECK_HEADERS(stddef.h utime.h wchar.h wctype.h limits.h)
-AC_CHECK_HEADERS(getopt.h err.h xlocale.h signal.h)
+AC_CHECK_HEADERS(getopt.h err.h xlocale.h)
 AC_CHECK_HEADERS(sys/mman.h sys/stat.h sys/types.h sys/utime.h sys/time.h)
 if test "$enable_zlib" != "no"; then
   AC_CHECK_HEADERS(zlib.h)
 fi
-AC_CHECK_TYPE([sig_t],[AC_DEFINE([HAVE_SIG_T],1,[Have sig_t type])],,[
-#ifdef HAVE_SIGNAL_H
-#include <signal.h>
-#endif])
+AC_CHECK_TYPE([sig_t],[AC_DEFINE([HAVE_SIG_T],1,[Have sig_t type])],,[#include <signal.h>])
 
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST

--- a/src/compress.c
+++ b/src/compress.c
@@ -47,12 +47,10 @@ FILE_RCSID("@(#)$File: compress.c,v 1.111 2018/09/11 16:33:21 christos Exp $")
 #include <errno.h>
 #include <ctype.h>
 #include <stdarg.h>
-#ifdef HAVE_SIGNAL_H
 #include <signal.h>
-# ifndef HAVE_SIG_T
+#ifndef HAVE_SIG_T
 typedef void (*sig_t)(int);
-# endif /* HAVE_SIG_T */
-#endif
+#endif /* HAVE_SIG_T */
 #if !defined(__MINGW32__) && !defined(WIN32)
 #include <sys/ioctl.h>
 #endif
@@ -228,16 +226,12 @@ file_zmagic(struct magic_set *ms, const struct buffer *b, const char *name)
 	int fd = b->fd;
 	const unsigned char *buf = b->fbuf;
 	size_t nbytes = b->flen;
-#ifdef HAVE_SIGNAL_H
 	sig_t osigpipe;
-#endif
 
 	if ((ms->flags & MAGIC_COMPRESS) == 0)
 		return 0;
 
-#ifdef HAVE_SIGNAL_H
 	osigpipe = signal(SIGPIPE, SIG_IGN);
-#endif
 	for (i = 0; i < ncompr; i++) {
 		int zm;
 		if (nbytes < compr[i].maglen)
@@ -308,9 +302,7 @@ file_zmagic(struct magic_set *ms, const struct buffer *b, const char *name)
 out:
 	DPRINTF("rv = %d\n", rv);
 
-#ifdef HAVE_SIGNAL_H
 	(void)signal(SIGPIPE, osigpipe);
-#endif
 	free(newbuf);
 	ms->flags |= MAGIC_COMPRESS;
 	DPRINTF("Zmagic returns %d\n", rv);


### PR DESCRIPTION
The `<signal.h>` header file is part of the standard C89 headers [1]
and on current systems can be included unconditionally.

Since file requires at least C89 or greater, the `HAVE_SIGNAL_H` symbol
defined by Autoconf in configure.ac [2] can be ommitted and simplifed.

Refs:
[1] https://port70.net/~nsz/c/c89/c89-draft.html#4.1.2
[2] https://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/headers.m4

Thank you.