### PR TITLE
avoid literal tabs in file output for PGP secret keys.

### DIFF
--- a/magic/Magdir/pgp
+++ b/magic/Magdir/pgp
@@ -517,9 +517,9 @@
 
 # PGP RSA (e=65537) secret (sub-)key header
 
-0	byte	0x95			PGP	Secret Key -
+0	byte	0x95			PGP Secret Key -
 >1	use	pgpkey
-0	byte	0x97			PGP	Secret Sub-key -
+0	byte	0x97			PGP Secret Sub-key -
 >1	use	pgpkey
 0	byte	0x9d
 # Update: Joerg Jenderek


### PR DESCRIPTION
currently file is outputting a literal tab symbol as "\011", like this:

```
0 dkg@alice:~$ file test.pgp
test.pgp: PGP\011Secret Key - 3072b created on Tue Apr  3 15:29:02 2018 - RSA (Encrypt or Sign) e=65537 hashed AES with 128-bit key Salted&Iterated S2K SHA-1
0 dkg@alice:~$
```

i don't think that \011 is useful for people, and i think the tab in
this changeset was originally intended to be a space.