### PR TITLE
archive: Add magic for Gentoo XPAK binary packages

### DIFF
--- a/magic/Magdir/archive
+++ b/magic/Magdir/archive
@@ -1427,3 +1427,9 @@
 
 # LyNX archive
 56	string	USE\040LYNX\040TO\040DISSOLVE\040THIS\040FILE	 LyNX archive
+
+# Gentoo XPAK binary package
+# by Michał Górny <mgorny@gentoo.org>
+# https://gitweb.gentoo.org/proj/portage.git/tree/man/xpak.5
+-4	string	STOP
+>-16	string	XPAKSTOP	Gentoo binary package (XPAK)


### PR DESCRIPTION
Add a simple magic for detecting Gentoo XPAK binary packages.
The package format is basically a compressed tarball followed by binary
metadata blob.

The most correct way to detect the format would probably be to first
check for 'STOP' at the end, read the unsigned long preceding it and use
it as (negative) offset from end of file where 'XPAKPACK' is to be
found.  However, file does not seem to support that kind of lookup.

Therefore, I went for the second best thing and checking for additional
'XPAKSTOP' terminating the metadata blob.

Technically, the information could be usefully amended by stating
the compression used.  However, it seems that positive offsets following
negative offsets do not work, and reversing the logic would require
a lot of repetition, so I presumed it's not worth the effort.