### PR TITLE
elf magic: add support for PA-RISC 1.0 and 1.1 ABIs

### DIFF
--- a/magic/Magdir/elf
+++ b/magic/Magdir/elf
@@ -38,6 +38,8 @@
 >0	lelong&0x3		2		relaxed memory ordering,
 
 0	name		elf-pa-risc
+>2	leshort		0x020B		1.0
+>2	leshort		0x0210		1.1
 >2	leshort		0x0214		2.0
 >0	leshort		&0x0008		(LP64)
 


### PR DESCRIPTION
Noticed unsupported arche values on old hppa chroots.
Minimal reproducer:

```
$ for abi in 1.0 1.1 2.0; do hppa-unknown-linux-gnu-gcc -march=$abi -c a.c -o a.o; file a.o; done
a.o: ELF 32-bit MSB relocatable, PA-RISC, *unknown arch 0xf* version 1 (GNU/Linux), not stripped
a.o: ELF 32-bit MSB relocatable, PA-RISC, *unknown arch 0xf* version 1 (GNU/Linux), not stripped
a.o: ELF 32-bit MSB relocatable, PA-RISC, 2.0 version 1 (GNU/Linux), not stripped
```

The change adds older ABI support:
```
$ for abi in 1.0 1.1 2.0; do hppa-unknown-linux-gnu-gcc -march=$abi -c a.c -o a.o; src/file a.o; done
a.o: ELF 32-bit MSB relocatable, PA-RISC, 1.0 version 1 (GNU/Linux), not stripped
a.o: ELF 32-bit MSB relocatable, PA-RISC, 1.1 version 1 (GNU/Linux), not stripped
a.o: ELF 32-bit MSB relocatable, PA-RISC, 2.0 version 1 (GNU/Linux), not stripped
```

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>