### PR TITLE
pcap sniffer: Print linktype value default match

### DIFF
--- a/magic/Magdir/sniffer
+++ b/magic/Magdir/sniffer
@@ -85,6 +85,8 @@
 0	name		pcap-be
 >4	beshort		x		- version %d
 >6	beshort		x		\b.%d
+# clear that continuation level match
+>20	clear		x
 >20	belong		0		(No link-layer encapsulation
 >20	belong		1		(Ethernet
 >20	belong		2		(3Mb Ethernet
@@ -186,7 +188,10 @@
 >20	belong		245		(NFC LLCP
 >20	belong		247		(Infiniband
 >20	belong		248		(SCTP
->16	belong		x		\b, capture length %d)
+>20	default		x
+# print default match
+>>20	belong		x		(linktype#%u
+>16	belong		x		\b, capture length %u)
 
 # packets time stamps in seconds and microseconds.
 0	ubelong		0xa1b2c3d4	pcap capture file, microseconds ts (big-endian)


### PR DESCRIPTION
Moreover:
Capture length is unsigned, thus use %u.