### PR TITLE
Clean headers checks in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -90,8 +90,8 @@ dnl Checks for headers
 AC_HEADER_STDC
 AC_HEADER_MAJOR
 AC_HEADER_SYS_WAIT
-AC_CHECK_HEADERS(stdint.h fcntl.h stdint.h inttypes.h unistd.h)
-AC_CHECK_HEADERS(stddef.h utime.h wchar.h wctype.h limits.h)
+AC_CHECK_HEADERS(stdint.h fcntl.h inttypes.h unistd.h)
+AC_CHECK_HEADERS(utime.h wchar.h wctype.h)
 AC_CHECK_HEADERS(getopt.h err.h xlocale.h)
 AC_CHECK_HEADERS(sys/mman.h sys/stat.h sys/types.h sys/utime.h sys/time.h)
 if test "$enable_zlib" != "no"; then


### PR DESCRIPTION
Changes:
- stdint.h was checked twice (duplicated check removed)
- stddef.h and limits.h are part of the C89+ standard (symbols in code
  have already been fixed and removed).