### PR TITLE
Remove HAVE_STRERROR

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -151,7 +151,7 @@ else
 fi])
 
 dnl Checks for functions
-AC_CHECK_FUNCS(strerror strndup strtoul mkstemp mkostemp utimes utime wcwidth strtof newlocale uselocale freelocale setlocale memmem)
+AC_CHECK_FUNCS(strndup strtoul mkstemp mkostemp utimes utime wcwidth strtof newlocale uselocale freelocale setlocale memmem)
 
 dnl Provide implementation of some required functions if necessary
 AC_REPLACE_FUNCS(getopt_long asprintf vasprintf strlcpy strlcat getline ctime_r asctime_r localtime_r gmtime_r pread strcasestr fmtcheck dprintf)

--- a/src/file.h
+++ b/src/file.h
@@ -553,13 +553,6 @@ extern const char *file_names[];
 extern const size_t file_nnames;
 #endif
 
-#ifndef HAVE_STRERROR
-extern int sys_nerr;
-extern char *sys_errlist[];
-#define strerror(e) \
-	(((e) >= 0 && (e) < sys_nerr) ? sys_errlist[(e)] : "Unknown error")
-#endif
-
 #ifndef HAVE_STRTOUL
 #define strtoul(a, b, c)	strtol(a, b, c)
 #endif


### PR DESCRIPTION
Checking for presence of the strerror function is no longer needed since it is part of the C89 standard [1] and can be safely assumed that all current systems have it.

1: https://port70.net/~nsz/c/c89/c89-draft.html

Thank you...