### PR TITLE
Remove HAVE_STRTOUL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -151,7 +151,7 @@ else
 fi])
 
 dnl Checks for functions
-AC_CHECK_FUNCS(strerror strndup strtoul mkstemp mkostemp utimes utime wcwidth strtof newlocale uselocale freelocale setlocale memmem)
+AC_CHECK_FUNCS(strerror strndup mkstemp mkostemp utimes utime wcwidth strtof newlocale uselocale freelocale setlocale memmem)
 
 dnl Provide implementation of some required functions if necessary
 AC_REPLACE_FUNCS(getopt_long asprintf vasprintf strlcpy strlcat getline ctime_r asctime_r localtime_r gmtime_r pread strcasestr fmtcheck dprintf)

--- a/src/file.h
+++ b/src/file.h
@@ -560,10 +560,6 @@ extern char *sys_errlist[];
 	(((e) >= 0 && (e) < sys_nerr) ? sys_errlist[(e)] : "Unknown error")
 #endif
 
-#ifndef HAVE_STRTOUL
-#define strtoul(a, b, c)	strtol(a, b, c)
-#endif
-
 #ifndef HAVE_PREAD
 ssize_t pread(int, void *, size_t, off_t);
 #endif


### PR DESCRIPTION
The strtoul function is part of C89 standard [1] and on current systems it can be safely assumed that is always available.

1: https://port70.net/~nsz/c/c89/c89-draft.html