### PR TITLE
Remove HAVE_SETLOCALE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -151,7 +151,7 @@ else
 fi])
 
 dnl Checks for functions
-AC_CHECK_FUNCS(strerror strndup strtoul mkstemp mkostemp utimes utime wcwidth strtof newlocale uselocale freelocale setlocale memmem)
+AC_CHECK_FUNCS(strerror strndup strtoul mkstemp mkostemp utimes utime wcwidth strtof newlocale uselocale freelocale memmem)
 
 dnl Provide implementation of some required functions if necessary
 AC_REPLACE_FUNCS(getopt_long asprintf vasprintf strlcpy strlcat getline ctime_r asctime_r localtime_r gmtime_r pread strcasestr fmtcheck dprintf)

--- a/src/file.c
+++ b/src/file.c
@@ -186,9 +186,7 @@ main(int argc, char *argv[])
 	char *progname;
 
 	/* makes islower etc work for other langs */
-#ifdef HAVE_SETLOCALE
 	(void)setlocale(LC_CTYPE, "");
-#endif
 
 #ifdef __EMX__
 	/* sh-like wildcard expansion! Shouldn't hurt at least ... */


### PR DESCRIPTION
The setlocale function should be always available since it is part of the C89 standard [1].

1: https://port70.net/~nsz/c/c89/c89-draft.html

Thank you.