### PR TITLE
Remove redundant memory.h file

### DIFF
--- a/src/ascmagic.c
+++ b/src/ascmagic.c
@@ -40,7 +40,6 @@ FILE_RCSID("@(#)$File: ascmagic.c,v 1.104 2019/05/07 02:27:11 christos Exp $")
 
 #include "magic.h"
 #include <string.h>
-#include <memory.h>
 #include <ctype.h>
 #include <stdlib.h>
 #ifdef HAVE_UNISTD_H

--- a/src/encoding.c
+++ b/src/encoding.c
@@ -40,7 +40,6 @@ FILE_RCSID("@(#)$File: encoding.c,v 1.20 2019/04/15 16:48:41 christos Exp $")
 
 #include "magic.h"
 #include <string.h>
-#include <memory.h>
 #include <stdlib.h>
 
 


### PR DESCRIPTION
The memory.h file is part of pre C89 era and is on today's systems only a simple wrapper for including the final string.h header file.