### PR TITLE
Remove obsolescent macro AC_C_CONST

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -100,7 +100,6 @@ fi
 AC_CHECK_TYPE([sig_t],[AC_DEFINE([HAVE_SIG_T],1,[Have sig_t type])],,[#include <signal.h>])
 
 dnl Checks for typedefs, structures, and compiler characteristics.
-AC_C_CONST
 AC_TYPE_OFF_T
 AC_TYPE_SIZE_T
 AC_CHECK_MEMBERS([struct stat.st_rdev])


### PR DESCRIPTION
Current systems all have the const keyword.

https://git.savannah.gnu.org/cgit/autoconf.git/tree/NEWS
https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/C-Compiler.html