### PR TITLE
Add modulefile detection

### DIFF
--- a/magic/Magdir/modulefile
+++ b/magic/Magdir/modulefile
@@ -1,0 +1,8 @@
+#------------------------------------------------------------------------------
+# modulefile:  file(1) magic for user's environment modulefile
+# URL: http://modules.sourceforge.net/
+# Reference: https://modules.readthedocs.io/en/stable/modulefile.html
+# From: Xavier Delaruelle <xavier.delaruelle@cea.fr>
+
+0	string	#%Module		modulefile
+!:mime	text/x-modulefile

--- a/magic/Makefile.am
+++ b/magic/Makefile.am
@@ -180,6 +180,7 @@ $(MAGIC_FRAGMENT_DIR)/mkid \
 $(MAGIC_FRAGMENT_DIR)/mlssa \
 $(MAGIC_FRAGMENT_DIR)/mmdf \
 $(MAGIC_FRAGMENT_DIR)/modem \
+$(MAGIC_FRAGMENT_DIR)/modulefile \
 $(MAGIC_FRAGMENT_DIR)/motorola \
 $(MAGIC_FRAGMENT_DIR)/mozilla \
 $(MAGIC_FRAGMENT_DIR)/msdos \


### PR DESCRIPTION
Add detection for user's environment [modulefiles](https://modules.readthedocs.io/en/stable/modulefile.html), which are script files describing changes to apply on a user shell environment with the [`module`](https://modules.readthedocs.io/en/stable/module.html) command.

