### PR TITLE
file.man: Correct magic xref to use __FSECTION__

### DIFF
--- a/doc/file.man
+++ b/doc/file.man
@@ -291,7 +291,7 @@ The magic pattern with the highest strength (see the
 option) comes first.
 .It Fl l , Fl Fl list
 Shows a list of patterns and their strength sorted descending by
-.Xr magic 4
+.Xr magic __FSECTION__
 strength
 which is used for the matching (see also the
 .Fl k


### PR DESCRIPTION
One of the cross-ref links to the `magic` man page still used a hardcoded `4` for the section number, rather than the dynamic `__FSECTION__` macro (which resolves to `5` on Linux).