### PR TITLE
Correctly detect hppa1.0 binaries created by GNU binutils (BFD)

### DIFF
--- a/magic/Magdir/elf
+++ b/magic/Magdir/elf
@@ -39,6 +39,7 @@
 
 0	name		elf-pa-risc
 >2	leshort		0x0208		1.0
+>2	leshort		0x020b		1.0
 >2	leshort		0x0210		1.1
 >2	leshort		0x0214		2.0
 >0	leshort		&0x0008		(LP64)


### PR DESCRIPTION
This patch simply adds support to correctly detect hppa1.0 ELF binaries.

Long description:
The GNU binutils #define hppa ELF binaries to be marked with those values (see binutils: include/elf/hppa.h):
#define EFA_PARISC_1_0                  0x020b
#define EFA_PARISC_1_1                  0x0210
#define EFA_PARISC_2_0                  0x0214

Since the value 0x020b (EFA_PARISC_1_0) is missing in the elf magic file, the 32-bit Linux kernel is currently detected wrongly ("unknown arch 0xf"), as can be seen here:

$ file  vmlinux
vmlinux: ELF 32-bit MSB executable, PA-RISC, *unknown arch 0xf* version 1 (GNU/Linux), statically linked, BuildID[sha1]=2825764ca2d71e726e7b75569cbea5f9dc3b0562, with debug_info, not stripped

With this patch it works correctly:
$ file -m /home/cvs/LINUX/file/magic/Magdir/elf   vmlinux
vmlinux: ELF 32-bit MSB executable, PA-RISC, 1.0 version 1 (GNU/Linux), statically linked, BuildID[sha1]=2825764ca2d71e726e7b75569cbea5f9dc3b0562, with debug_info, not stripped

I did not deleted the magic entry for 0x0208, because maybe it's used that way on HP-UX. I simply don't know....

Please pull.
Thanks,
Helge Deller
(PA-RISC Linux kernel maintainer)