### PR TITLE
add loongarch ELF file type

### DIFF
--- a/magic/Magdir/elf
+++ b/magic/Magdir/elf
@@ -289,6 +289,7 @@
 >>>48	use		elf-riscv
 >18	leshort		247		eBPF,
 >18	leshort		251             NEC VE,
+>18	leshort		258		LoongArch,
 >18	leshort		0x1057		AVR (unofficial),
 >18	leshort		0x1059		MSP430 (unofficial),
 >18	leshort		0x1223		Adapteva Epiphany (unofficial),


### PR DESCRIPTION
Add loongarch support for file, please review, thanks.

Before:
```
/bin/ls: ELF 64-bit LSB executable, *unknown arch 0x102* version 1 (SYSV), dynamically linked, interpreter /lib64/ld.so.1, for GNU/Linux 4.15.0, BuildID[sha1]=a3774724aa17c3a0560c06a61687cfea23bfa38a, stripped
```
After:
```
/bin/ls: ELF 64-bit LSB executable, LoongArch, version 1 (SYSV), dynamically linked, interpreter /lib64/ld.so.1, for GNU/Linux 4.15.0, BuildID[sha1]=a3774724aa17c3a0560c06a61687cfea23bfa38a, stripped
```