### PR TITLE
bcachefs probe extensions

### DIFF
--- a/magic/Magdir/filesystems
+++ b/magic/Magdir/filesystems
@@ -2488,5 +2488,14 @@
 >>0x1010	uleshort	x	\b, version %u
 >>0x1012	uleshort	x	\b, min version %u
 >>0x107a	byte		x	\b, device %d
+# assumes the first field is the members field
+>>0x12f4	ulelong		0x01
+>>>0x12f0	default		x
+>>>&(0x107a.b*56)	ubelong	x	\b/UUID=%08x
+>>>>&0		ubeshort	x	\b-%04x
+>>>>&2		ubeshort	x	\b-%04x
+>>>>&4		ubeshort	x	\b-%04x
+>>>>&6		ubelong		x	\b-%08x
+>>>>&10		ubeshort	x	\b%04x
 >>0x107b	byte		x	\b, %d devices
 >>0x1090	byte		^0x02	\b (unclean)

--- a/magic/Magdir/filesystems
+++ b/magic/Magdir/filesystems
@@ -2478,7 +2478,12 @@
 # From: Thomas Weiﬂschuh <thomas@t-8ch.de>
 0x1018		string		\xc6\x85\x73\xf6\x4e\x1a\x45\xca\x82\x65\xf5\x7f\x48\xba\x6d\x81	bcachefs
 >0x1068		lequad		8
->>0x1038	guid		x	\b, UUID=%s
+>>0x1038	ubelong		x	\b, UUID=%08x
+>>0x103c	ubeshort	x	\b-%04x
+>>0x103e	ubeshort	x	\b-%04x
+>>0x1040	ubeshort	x	\b-%04x
+>>0x1042	ubelong		x	\b-%08x
+>>0x1046	ubeshort	x	\b%04x
 >>0x1048	string		>0	\b, label "%.32s"
 >>0x1010	uleshort	x	\b, version %u
 >>0x1012	uleshort	x	\b, min version %u

--- a/tests/bcachefs.result
+++ b/tests/bcachefs.result
@@ -1,1 +1,1 @@
-bcachefs, UUID=46bd306f-80ad-4cd0-af4f-147e7d85f393, label "Label", version 13, min version 13, device 0, 1 devices
+bcachefs, UUID=46bd306f-80ad-4cd0-af4f-147e7d85f393, label "Label", version 13, min version 13, device 0/UUID=72a60ede-4cb6-4374-aa70-cb38a50af5ef, 1 devices

--- a/tests/bcachefs.result
+++ b/tests/bcachefs.result
@@ -1,1 +1,1 @@
-bcachefs, UUID=6F30BD46-AD80-D04C-AF4F-147E7D85F393, label "Label", version 13, min version 13, device 0, 1 devices
+bcachefs, UUID=46bd306f-80ad-4cd0-af4f-147e7d85f393, label "Label", version 13, min version 13, device 0, 1 devices


### PR DESCRIPTION
* fixes parsing of filesystem UUID (See #106)
* Adds parsing of device UUID