### PR TITLE
Use official name LoongArch for EM_LOONGARCH.

### DIFF
--- a/magic/Magdir/elf
+++ b/magic/Magdir/elf
@@ -303,7 +303,7 @@
 >18	leshort		255		Synopsys ARCv3 32-bit,
 >18	leshort		256		Kalray VLIW core of the MPPA family,
 >18	leshort		257		WDC 65816/65C816,
->18	leshort		258		Loongson Loongarch,
+>18	leshort		258		LoongArch,
 >18	leshort		259		ChipON KungFu32,
 >18	leshort		0x1057		AVR (unofficial),
 >18	leshort		0x1059		MSP430 (unofficial),


### PR DESCRIPTION
The official name for Loongson Architecture is LoongArch, it is better to use LoongArch instead of Loongson Loongarch for EM_LOONGARCH to avoid confusion and keep consistent with the various of software in the future.

The official documentation in Chinese: http://www.loongson.cn/uploadfile/cpu/LoongArch.pdf
The translated version in English: https://loongson.github.io/LoongArch-Documentation/

The last [PR](https://github.com/file/file/pull/103#issue-567454184) wanted to use LoongArch, and the upstream binutils has made the same change: https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=01a8c731aacbdbed0eb5682d13cc074dc7e25fb3
