### PR TITLE
Add missing MIME type for Mobipocket E-books

### DIFF
--- a/magic/Magdir/palm
+++ b/magic/Magdir/palm
@@ -55,6 +55,7 @@
 # Mobipocket (www.mobipocket.com), donated by Carl Witty
 # expanded by Ralf Brown
 60		string	 	BOOKMOBI	Mobipocket E-book
+!:mime	application/x-mobipocket-ebook
 # MobiPocket stores a full title, pointed at by the belong at offset
 # 0x54 in its header at (78.L), with length given by the belong at
 # offset 0x58.


### PR DESCRIPTION
Kindle, for one, seems to expect this MIME type.

Even if this isn't a whitepaper standard, there's [tons of results expecting or setting it for this particular file type](https://github.com/search?q=application%2Fx-mobipocket-ebook&type=code).

Likely solves:
- https://bugs.launchpad.net/ubuntu/+source/mime-support/+bug/916753
- https://github.com/symfony/symfony/issues/24862