### PR TITLE
protect fstat

### DIFF
--- a/src/seccomp.c
+++ b/src/seccomp.c
@@ -177,7 +177,9 @@ enable_sandbox_full(void)
 #endif
 	ALLOW_RULE(fcntl);
  	ALLOW_RULE(fcntl64);
+#ifdef __NR_fstat
 	ALLOW_RULE(fstat);
+#endif
  	ALLOW_RULE(fstat64);
 #ifdef __NR_fstatat64
 	ALLOW_RULE(fstatat64);


### PR DESCRIPTION
`fstat` can be replaced by `statx` in kernel, on some architectures, such as LoongArch, `fstat` syscall does not exist.