### PR TITLE
Fix use-after-free with large file -f list

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -535,6 +535,7 @@ out:		file_err(EXIT_FAILURE, "Cannot allocate memory for file list");
 			char **nf = realloc(flist, fimax * sizeof(*flist));
 			if (nf == NULL)
 				goto out;
+			flist = nf;
 		}
 		flist[fi++] = line;
 		cwid = file_mbswidth(ms, line);


### PR DESCRIPTION
This results in crashes during Fedora rawhide package builds: https://bugzilla.redhat.com/show_bug.cgi?id=2110622