### PR TITLE
sniffer: Update a libpcap entry

### DIFF
--- a/magic/Magdir/sniffer
+++ b/magic/Magdir/sniffer
@@ -198,7 +198,7 @@
 >20	belong&0x03FFFFFF		204		(PPP with direction pseudo-header
 >20	belong&0x03FFFFFF		205		(Cisco HDLC with direction pseudo-header
 >20	belong&0x03FFFFFF		206		(Frame Relay with direction pseudo-header
->20	belong&0x03FFFFFF		209		(Linux IPMB
+>20	belong&0x03FFFFFF		209		(Linux I2C
 >20	belong&0x03FFFFFF		215		(802.15.4 with non-ASK PHY header
 >20	belong&0x03FFFFFF		216		(Linux evdev events
 >20	belong&0x03FFFFFF		219		(MPLS with label as link-layer header


### PR DESCRIPTION
s/Linux IPMB/Linux I2C/

In accordance with this commit in the libpcap repository:
commit cdc5ae624182fd1799a03df3f43bdc4f40926563
Date:   Thu Apr 25 23:48:11 2024 -0700

    Rename {LINKTYPE,DLT}_IPMB_LINUX to {LINKTYPE,DLT}_I2C_LINUX.