### PR TITLE
JPEG2000 misidentified as SIMH-tape-data

### DIFF
--- a/src/is_simh.c
+++ b/src/is_simh.c
@@ -91,15 +91,18 @@ swap4(uint32_t sv)
 
 
 static uint32_t
-getlen(const unsigned char **uc)
+getlen(const unsigned char **uc, int *err)
 {
 	uint32_t n;
 	memcpy(&n, *uc, sizeof(n));
+	*err = 0;
 	*uc += sizeof(n);
 	if (NEED_SWAP)
 		n = swap4(n);
 	if (n == 0xffffffff)	/* check for End of Medium */
 		return n;
+	/* Check bits 25 to 28 are not used */
+	*err = ((n & 0x00ffffff) != (n & 0x0fffffff));
 	n &= 0x00ffffff;	/* keep only the record len */
 	if (n & 1)
 		n++;
@@ -112,11 +115,14 @@ simh_parse(const unsigned char *uc, const unsigned char *ue)
 	uint32_t nbytes, cbytes;
 	const unsigned char *orig_uc = uc;
 	size_t nt = 0, nr = 0;
+	int err = 0;
 
 	(void)memcpy(simh_bo.s, "\01\02\03\04", 4);
 
 	while (ue - uc >= CAST(ptrdiff_t, sizeof(nbytes))) {
-		nbytes = getlen(&uc);
+		nbytes = getlen(&uc, &err);
+		if (err)
+			return 0;
 		if ((nt > 0 || nr > 0) && nbytes == 0xFFFFFFFF)
 			/* EOM after at least one record or tapemark */
 			break;
@@ -132,7 +138,9 @@ simh_parse(const unsigned char *uc, const unsigned char *ue)
 		uc += nbytes;
 		if (ue - uc < CAST(ptrdiff_t, sizeof(nbytes)))
 			break;
-		cbytes = getlen(&uc);
+		cbytes = getlen(&uc, &err);
+		if (err)
+			return 0;
 		if (nbytes != cbytes)
 			return 0;
 		nr++;


### PR DESCRIPTION
In file 5.45, some JPEG2000 images are misidentified as "application/SIMH-tape-data"

Indeed, as soon as the code in is_simh.c detects SIMH data, this identification wins regardless of the pattern given in the Magic directory.

In the case of JPEG2000, all files start with the magic pattern (in Big Endian) :
\x00\x00\x00\x0C\x6A\x50\x20\x20

In simh.c, the first 4 bytes (in Little Endian) are masked to retrieve the lower 24 bits leading to 0 (TAPEMARK)
The next 4 bytes gives the length of the record also masked : 0x25205069
The end of the record is looked after at offset 0x205072
And when the masked 4 bytes matches (0x20506A) a data record is found.
The next data record can't be verified since it usually goes beyond 7MiB looked at
        # define FILE_BYTES_MAX (7 * 1024 * 1024)/* how much of the file to look at */

So because of the masking in the header, every JPEG2000 that happens to have 0x20506A
at the offset 0x205072 is considered SIMH data.

The proposed correction adds just one verification that, conforming to
the spec (http://simh.trailing-edge.com/docs/simh_magtape.pdf),
bits 25 to 28 in header/trailing data are zeros when a length is provided.

This makes all JPEG2000 (starting with \x00\x00\x00\x0C) never be considered as SIHM data.

Unfortunately, I have no SIHM files to verify this works for them.