### PR TITLE
Replace "OpenBSD OPENFLOW" by "OpenBSD OpenFlow"

### DIFF
--- a/magic/Magdir/sniffer
+++ b/magic/Magdir/sniffer
@@ -249,7 +249,7 @@
 >20	belong&0x03FFFFFF		264		(ISO 14443 messages
 >20	belong&0x03FFFFFF		265		(IEC 62106 Radio Data System groups
 >20	belong&0x03FFFFFF		266		(USB with Darwin header
->20	belong&0x03FFFFFF		267		(OpenBSD OPENFLOW
+>20	belong&0x03FFFFFF		267		(OpenBSD OpenFlow
 >20	belong&0x03FFFFFF		268		(IBM SDLC frames
 >20	belong&0x03FFFFFF		269		(TI LLN sniffer frames
 >20	belong&0x03FFFFFF		271		(Linux vsock


### PR DESCRIPTION
To match the naming in OpenBSD and sync with a libpcap update.