### PR TITLE
riff: fix WebP VP8L alpha detection

### DIFF
--- a/magic/Magdir/riff
+++ b/magic/Magdir/riff
@@ -161,7 +161,7 @@
 >>>>>15		byte&0x40	=0x00	\b, decoders should clamp
 >0  string  VP8L
 >>8		byte		0x2f	\b, lossless
->>>11		byte		&0x01	\b, with alpha
+>>>12		byte		&0x10	\b, with alpha
 >0  string  VP8X
 >>4		lelong		0x0a
 >>>8		byte		&0x02	\b, animated


### PR DESCRIPTION
the spec basically says it reads the bytes of a VP8L chunk in big endian order, but the bits of each byte in reverse.

so the 29th bit would be 4th byte &  `(1 << (7 - (32 - 29))) == 0x10`.

getting the image dimensions from this format is very difficult because of this. per-byte bit reversal of a big endian uint32_t, then decode it into 2 packed 14-bit integers at the high end, then add 1 ...