### PR TITLE
Fix. file.c spelling errors

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -522,7 +522,7 @@ unwrap(struct magic_set *ms, const char *fn)
 		f = stdin;
 	else {
 		if ((f = fopen(fn, "r")) == NULL) {
-			file_warn("Cannot open `%s'", fn);
+			file_warn("Cannot open '%s'", fn);
 			return 1;
 		}
 	}


### PR DESCRIPTION
Fix misspellings in file.c file
file_warn("Cannot open `%s'", fn); => file_warn("Cannot open '%s'", fn);