### PR TITLE
add landlock

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,11 @@ AC_ARG_ENABLE([libseccomp],
 [AS_HELP_STRING([--disable-libseccomp], [disable libseccomp sandboxing @<:@default=auto@:>@])])
 AC_MSG_RESULT($enable_libseccomp)
 
+AC_MSG_CHECKING(for Landlock LSM support)
+AC_ARG_ENABLE([landlock],
+[AS_HELP_STRING([--disable-landlock], [disable Landlock filesystem sandboxing @<:@default=auto@:>@])])
+AC_MSG_RESULT($enable_landlock)
+
 AC_MSG_CHECKING(for file formats in man section 5)
 AC_ARG_ENABLE(fsect-man5,
 [  --enable-fsect-man5      enable file formats in man section 5],
@@ -228,6 +233,9 @@ fi
 
 if test "$enable_libseccomp" != "no"; then
     AC_CHECK_LIB(seccomp, seccomp_init)
+fi
+if test "$enable_landlock" != "no"; then
+    AC_CHECK_HEADERS(linux/landlock.h)
 fi
 if test "$MINGW" = 1; then
   AC_CHECK_LIB(gnurx,regexec,,AC_MSG_ERROR([libgnurx is required to build file(1) with MinGW]))

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,7 +20,7 @@ MINGWLIBS =
 endif
 libmagic_la_LIBADD = -lm $(LTLIBOBJS) $(MINGWLIBS)
 
-file_SOURCES = file.c seccomp.c
+file_SOURCES = file.c seccomp.c landlock.c
 file_LDADD = libmagic.la -lm
 CLEANFILES = magic.h
 EXTRA_DIST = magic.h.in cdf.mk BNF memtest.c

--- a/src/file.c
+++ b/src/file.c
@@ -336,6 +336,9 @@ main(int argc, char *argv[])
 #ifdef HAVE_LIBSECCOMP
 			(void)fprintf(stdout, "seccomp support included\n");
 #endif
+#ifdef HAVE_LINUX_LANDLOCK_H
+			(void)fprintf(stdout, "Landlock support included\n");
+#endif
 			return 0;
 		case 'z':
 			flags |= MAGIC_COMPRESS;
@@ -363,6 +366,11 @@ main(int argc, char *argv[])
 	}
 	if (e)
 		return e;
+
+#ifdef HAVE_LINUX_LANDLOCK_H
+	if (sandbox && enable_landlock(flags, action) == -1)
+		file_err(EXIT_FAILURE, "Landlock initialisation failed");
+#endif /* HAVE_LINUX_LANDLOCK_H */
 
 #ifdef HAVE_LIBSECCOMP
 	if (sandbox && enable_sandbox() == -1)

--- a/src/file.h
+++ b/src/file.h
@@ -704,6 +704,10 @@ const char *fmtcheck(const char *, const char *)
 int enable_sandbox(void);
 #endif
 
+#ifdef HAVE_LINUX_LANDLOCK_H
+int enable_landlock(int, int);
+#endif
+
 file_protected const char *file_getprogname(void);
 file_protected void file_setprogname(const char *);
 file_protected void file_err(int, const char *, ...)

--- a/src/landlock.c
+++ b/src/landlock.c
@@ -1,0 +1,155 @@
+/* Landlock sandbox: read anywhere, write only in $TMPDIR. */
+#include "file.h"
+
+#if HAVE_LINUX_LANDLOCK_H
+#include "magic.h"
+#include <linux/landlock.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+
+/* glibc only got Landlock wrappers in 2.40, so call via syscall(2). */
+#ifndef landlock_create_ruleset
+static inline int
+landlock_create_ruleset(const struct landlock_ruleset_attr *attr,
+    size_t size, uint32_t flags)
+{
+	return CAST(int, syscall(__NR_landlock_create_ruleset, attr, size,
+	    flags));
+}
+#endif
+
+#ifndef landlock_add_rule
+static inline int
+landlock_add_rule(int ruleset_fd, enum landlock_rule_type rule_type,
+    const void *rule_attr, uint32_t flags)
+{
+	return CAST(int, syscall(__NR_landlock_add_rule, ruleset_fd,
+	    rule_type, rule_attr, flags));
+}
+#endif
+
+#ifndef landlock_restrict_self
+static inline int
+landlock_restrict_self(int ruleset_fd, uint32_t flags)
+{
+	return CAST(int, syscall(__NR_landlock_restrict_self, ruleset_fd,
+	    flags));
+}
+#endif
+
+/* A missing path (e.g. unset $TMPDIR) is not fatal, just skipped. */
+static int
+landlock_allow_path(int ruleset_fd, const char *path, uint64_t allowed)
+{
+	struct landlock_path_beneath_attr pb;
+	int rv;
+
+	pb.allowed_access = allowed;
+	pb.parent_fd = open(path, O_PATH | O_CLOEXEC);
+	if (pb.parent_fd == -1)
+		return errno == ENOENT ? 0 : -1;
+	rv = landlock_add_rule(ruleset_fd, LANDLOCK_RULE_PATH_BENEATH, &pb, 0);
+	(void)close(pb.parent_fd);
+	return rv;
+}
+
+int
+enable_landlock(int flags, int action)
+{
+	struct landlock_ruleset_attr attr;
+	struct stat sb;
+	int ruleset_fd, abi, needs_write;
+	const char *tmpdir;
+
+	(void)flags;
+
+	/* Magic build modes write outside /tmp; just skip Landlock
+	   for those. seccomp still applies. */
+	if (action == FILE_COMPILE || action == FILE_CHECK ||
+	    action == FILE_LIST)
+		return 0;
+
+	/* Pipe input gets copied to a tempfile in /tmp. */
+	needs_write = fstat(STDIN_FILENO, &sb) == 0 && S_ISFIFO(sb.st_mode);
+
+	abi = CAST(int, syscall(__NR_landlock_create_ruleset, NULL, 0,
+	    LANDLOCK_CREATE_RULESET_VERSION));
+	if (abi < 1)
+		return 0;
+
+	(void)memset(&attr, 0, sizeof(attr));
+	attr.handled_access_fs =
+	    LANDLOCK_ACCESS_FS_EXECUTE |
+	    LANDLOCK_ACCESS_FS_WRITE_FILE |
+	    LANDLOCK_ACCESS_FS_READ_FILE |
+	    LANDLOCK_ACCESS_FS_READ_DIR |
+	    LANDLOCK_ACCESS_FS_REMOVE_DIR |
+	    LANDLOCK_ACCESS_FS_REMOVE_FILE |
+	    LANDLOCK_ACCESS_FS_MAKE_CHAR |
+	    LANDLOCK_ACCESS_FS_MAKE_DIR |
+	    LANDLOCK_ACCESS_FS_MAKE_REG |
+	    LANDLOCK_ACCESS_FS_MAKE_SOCK |
+	    LANDLOCK_ACCESS_FS_MAKE_FIFO |
+	    LANDLOCK_ACCESS_FS_MAKE_BLOCK |
+	    LANDLOCK_ACCESS_FS_MAKE_SYM;
+#ifdef LANDLOCK_ACCESS_FS_REFER
+	if (abi >= 2)
+		attr.handled_access_fs |= LANDLOCK_ACCESS_FS_REFER;
+#endif
+#ifdef LANDLOCK_ACCESS_FS_TRUNCATE
+	if (abi >= 3)
+		attr.handled_access_fs |= LANDLOCK_ACCESS_FS_TRUNCATE;
+#endif
+#ifdef LANDLOCK_ACCESS_NET_BIND_TCP
+	if (abi >= 4) {
+		attr.handled_access_net =
+		    LANDLOCK_ACCESS_NET_BIND_TCP |
+		    LANDLOCK_ACCESS_NET_CONNECT_TCP;
+	}
+#endif
+
+	ruleset_fd = landlock_create_ruleset(&attr, sizeof(attr), 0);
+	if (ruleset_fd == -1)
+		return -1;
+
+	if (landlock_allow_path(ruleset_fd, "/",
+	    LANDLOCK_ACCESS_FS_READ_FILE | LANDLOCK_ACCESS_FS_READ_DIR) == -1)
+		goto fail;
+
+	if (needs_write) {
+		uint64_t tmp_access =
+		    LANDLOCK_ACCESS_FS_READ_FILE |
+		    LANDLOCK_ACCESS_FS_READ_DIR |
+		    LANDLOCK_ACCESS_FS_WRITE_FILE |
+		    LANDLOCK_ACCESS_FS_MAKE_REG |
+		    LANDLOCK_ACCESS_FS_REMOVE_FILE;
+#ifdef LANDLOCK_ACCESS_FS_TRUNCATE
+		if (abi >= 3)
+			tmp_access |= LANDLOCK_ACCESS_FS_TRUNCATE;
+#endif
+		tmpdir = getenv("TMPDIR");
+		if (tmpdir == NULL || *tmpdir == '\0')
+			tmpdir = "/tmp";
+		if (landlock_allow_path(ruleset_fd, tmpdir, tmp_access) == -1)
+			goto fail;
+	}
+
+	if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) == -1)
+		goto fail;
+	if (landlock_restrict_self(ruleset_fd, 0) == -1)
+		goto fail;
+
+	(void)close(ruleset_fd);
+	return 0;
+fail:
+	(void)close(ruleset_fd);
+	return -1;
+}
+
+#endif /* HAVE_LINUX_LANDLOCK_H */


### PR DESCRIPTION
This adds landlock to the existing sandbox.
Unlike seccomp, it is much less prone to breaking when dependencies or features change.
It isolates filesystem and network where possible using the kernel lsm which is available on modern distros by default.

in combination with seccomp it provides a solid process isolation that should hold even against serious attempts to circumvent it.