### PR TITLE
filesystems magic: fix exFAT filesystem detection

### DIFF
--- a/magic/Magdir/filesystems
+++ b/magic/Magdir/filesystems
@@ -261,18 +261,6 @@
 # for sector sizes with 512 or more Bytes
 >0x1FE		leshort		0xAA55		DOS/MBR boot sector
 
-# ExFAT
-3		string/w	=EXFAT
->0x1FE		leshort		0xAA55
->>0x6E		ubyte		1
->>>0x6F		ubyte		0x80
->>>0		ubyte		0xEB	DOS/MBR boot sector,
->>>0x69		ubyte		x	ExFAT Filesystem version %d.
->>>0x68		ubyte		x	\b%d
->>>0x6d		ubyte		x	\b, (1<<%d) sectors per cluster
->>>0x48		ulequad		x	\b, sectors %lld
->>>0x64		ulelong		x	\b, serial number %#x
-
 # keep old DOS/MBR boot sector as dummy for mbr and bootloader displaying
 # only for sector sizes with 512 or more Bytes
 0x1FE          leshort         0xAA55         	DOS/MBR boot sector
@@ -1057,6 +1045,20 @@
 >>>>>>>466	ubyte	0x05			\b, extended partition table
 >>>>>>>466	ubyte	0x0F			\b, extended partition table (LBA)
 >>>>>>>466	ubyte	0x0			\b, extended partition table (last)
+
+# exFAT
+# x86 real mode relative jump followed by string "EXFAT   "
+>0		string		\xEB\x76\x90EXFAT\ \ \ 	\b, ExFAT Filesystem
+>>0x6E		ubyte		<3			\b, numer of FATs %d
+>>>0x69		ubyte		x			\b, revision %d.
+>>>0x68		ubyte		x			\b%d
+>>>0x6C		ubyte		x			\b, (1<<%d) bytes per sector
+>>>0x6D		ubyte		x			\b, (1<<%d) sectors per cluster
+>>>0x48		ulequad		x			\b, sectors %lld
+>>>0x64		ulelong		x			\b, serial number %#x
+# MS Windows compat, SD association SDXC spec part 2
+>>>0x1B8	ulelong		>0			\b, with MBR disk signature %#-.4x
+>>>>0x1C6	ulelong		0			\b, recursive partition
 
 # DOS x86 sector separated and moved from "DOS/MBR boot sector" by Joerg Jenderek at May 2011
 


### PR DESCRIPTION
Detection of exFAT volume magic was broken due to the confusion in the DOS/MBR magic detecion logic caused by the MBR disk signature magic(AA55) in exFAT volume headers. This patch fixes the issue by nesting the exFAT volume magic in the existing DOS/MBR chain.

Also, print information on MBR partition table, including:

 - Disk signature(aka. "serial")
 - Whether it contains a recursive partition