### PR TITLE
Add MIME type for XBM magic entry

### DIFF
--- a/magic/Magdir/xwindows
+++ b/magic/Magdir/xwindows
@@ -38,6 +38,7 @@
 # X bitmap https://en.wikipedia.org/wiki/X_BitMap
 0	search/2048	#define\040
 >&0	regex		[a-zA-Z0-9]+_width\040	xbm image
+!:mime	image/x-xbitmap
 >>&0	regex		[0-9]+			(%sx
 >>>&0	string		\n#define\040
 >>>>&0	regex		[a-zA-Z0-9]+_height\040


### PR DESCRIPTION
# Add MIME type for XBM magic entry

The existing XBM magic entry in `magic/Magdir/xwindows` identifies XBM files for normal descriptive output, but it does not provide a MIME type.

Before this change:

```sh
$ file test.xbm
test.xbm: xbm image (1x1), ASCII text

$ file --mime-type test.xbm
test.xbm: text/plain
```

This can cause tools that rely on `file --mime-type`, such as `xdg-mime query filetype`, to treat `.xbm` files as plain text instead of images.

This change adds:

```text
!:mime image/x-xbitmap
```

to the existing XBM rule.

After this change:

```sh
$ file --mime-type test.xbm
test.xbm: image/x-xbitmap
```

`image/x-xbitmap` is already used by shared-mime-info for `.xbm` files.

Tested with:

```sh
cat > test.xbm <<'EOF'
#define test_width 1
#define test_height 1
static unsigned char test_bits[] = { 0x00 };
EOF

file -m magic/Magdir/xwindows test.xbm
file -m magic/Magdir/xwindows --mime-type test.xbm
```
