### PR TITLE
Update FreeArc archive string format (removed URL)

### DIFF
--- a/magic/Magdir/compress
+++ b/magic/Magdir/compress
@@ -375,7 +375,7 @@
 >5	byte		x		\b.%d
 >6	belong		x		(%d bytes)
 
-0	string		ArC\x01		FreeArc archive <http://freearc.org>
+0	string		ArC\x01		FreeArc archive
 
 # Valve Pack (VPK) files
 # https://developer.valvesoftware.com/wiki/VPK_(file_format)#File_Format


### PR DESCRIPTION
Removed the URL from the FreeArc archive string, because the official website is down since 2016.