### PR TITLE
seccomp: allow dup3, used by dup2() on architectures with no dup2 syscall

### DIFF
--- a/src/seccomp.c
+++ b/src/seccomp.c
@@ -100,6 +100,15 @@ enable_sandbox(int flags, int action)
 	ALLOW_RULE(brk);
 	ALLOW_RULE(close);
 	ALLOW_RULE(dup2);
+#ifdef __NR_dup3
+	/*
+	 * Some architectures have no dup2 syscall -- notably those whose
+	 * syscall table comes from asm-generic/unistd.h (aarch64, riscv64,
+	 * loongarch64) -- and glibc and musl implement dup2(old, new)
+	 * there as dup3(old, new, 0).  Used in file_pipe2file().
+	 */
+	ALLOW_RULE(dup3);
+#endif
 	ALLOW_RULE(exit);
 	ALLOW_RULE(exit_group);
 #ifdef __NR_faccessat


### PR DESCRIPTION
On architectures with no `dup2` syscall, `file -` is killed with `SIGSYS` when an ELF arrives on a pipe.

### Reproducer (aarch64, sandbox enabled)

```console
$ cat /usr/bin/file | file -
Bad system call (core dumped)

$ cat /usr/bin/file | file -S -
/dev/stdin: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), ...
```

Three conditions are needed: an **ELF** (the ELF reader seeks, which is what routes a pipe through `file_pipe2file()`), on a **non-seekable stdin**, with the **sandbox on**. `file /usr/bin/file` and `file - < /usr/bin/file` are both fine.

### Cause

`file_pipe2file()` ends with `dup2(tfd, fd)` (`src/compress.c:585`). Architectures whose syscall table comes from `asm-generic/unistd.h` — aarch64, riscv64, loongarch64 — have no `dup2` syscall; glibc and musl both implement `dup2(old, new)` there as `dup3(old, new, 0)`.

`SCMP_SYS(dup2)` resolves to a negative pseudo-syscall on those architectures (`__PNR_dup2 == -10152`), and `seccomp_rule_add()` then *silently skips* the rule. That is its documented best-effort behaviour — it returns **0**, not an error — so `ALLOW_RULE`'s check cannot catch it:

```c
scmp_filter_ctx c = seccomp_init(SCMP_ACT_KILL);
seccomp_rule_add(c, SCMP_ACT_ALLOW, SCMP_SYS(dup2), 0);  /* aarch64: SCMP_SYS = -10152, rc = 0 */
```

So nothing is allowlisted, and the default `SCMP_ACT_KILL` applies to `dup3` (syscall 24).

Confirmed from a core dump — `si_code: SYS_SECCOMP`, and:

```
_sigsys = {_call_addr = 0xffff718c00fc <dup2+28>, _syscall = 24, _arch = 0xC00000B7 /* AUDIT_ARCH_AARCH64 */}
```

The neighbouring `getpid`/`getrandom` rules are already commented *"Used by glibc in file_pipe2file()"*, and `umask`/`unlinkat` sit in the `needs_write` block for the same function — `dup2` is the one syscall in `file_pipe2file()` whose modern spelling was missed.

### Testing

- `make check` passes (the suite drives libmagic directly and never enables the sandbox, which is why this wasn't caught).
- A/B on the same tree, `--enable-libseccomp`, aarch64 glibc: unpatched `cat /usr/bin/file | ./src/file -` exits 159 (`128+SIGSYS`); patched it prints the ELF description and exits 0.

### Unrelated observation, not addressed here

The audit that found this also flags `ALLOW_RULE(select)` as a no-op on aarch64 (`__PNR_select`), while glibc's `select()` there uses `pselect6` (72), which is not allowlisted. I could not construct a case that reaches it — `sread()` short-circuits with `if (fd == STDIN_FILENO) goto nocheck;` before the `select()` call at `src/compress.c:476` — so I've left it alone rather than guess. Flagging it in case it is reachable by a path I didn't find.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
